### PR TITLE
Show details correctly when clicking on a BL thumbnail

### DIFF
--- a/src/Components/BucketList/BucketListThumbnail.js
+++ b/src/Components/BucketList/BucketListThumbnail.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 const BucketListThumbnail = ({ name, river, state, image, id, season }) => {
 // If need reference, look at tomatillos, similar functionality to the movie details page
   return(
-    <Link to={`/${id}`} className="bl-thumbnail" id={id}>
+    <Link to={`/rivers/${id}`} className="bl-thumbnail" id={id}>
       <div className="thumbnail-styling">
         <div>
           <h3 className="thumbnail-title" >{name}, {river.join(' | ')}</h3>


### PR DESCRIPTION
# Description

This PR fixes the bug that happened when a user attempted to view a thumbnail's details from the BL page.

## Issues

Closes #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Cosmetic changes (changes to layout or visuals in CSS file)


## How Has This Been Tested?

- [ ] console.log()
- [ ] dev tools
- [x] functionality check through web browser
- [ ] tested by viewing the markdown file preview
- [ ] tested with testing framework (Cypress)


## Checklist:

- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deleted all comments/console.log() after functionality and understanding is final
- [x] I have added any issues closed by this PR in the Issues section.
- [ ] I have added others as reviewers
